### PR TITLE
use different pid on each try

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ And like this on a connection failure:
 steps:
   - command: 'yarn && yarn saucelabs-based-tests'
     plugins:
-      joscha/sauce-connect#v2.0.0: ~
+      joscha/sauce-connect#v2.0.1: ~
 ```
 
 ## Configuration
@@ -32,7 +32,7 @@ The tunnel identifier to use, by default it will use the Buildkite Job ID (`BUIL
 steps:
   - command: 'yarn && yarn saucelabs-based-tests'
     plugins:
-      joscha/sauce-connect#v2.0.0:
+      joscha/sauce-connect#v2.0.1:
         tunnel-identifier: "my-custom-tunnel-id"
 ```
 
@@ -44,7 +44,7 @@ The Sauce Connect version to use, available versions, see [here](https://wiki.sa
 steps:
   - command: 'yarn && yarn saucelabs-based-tests'
     plugins:
-      joscha/sauce-connect#v2.0.0:
+      joscha/sauce-connect#v2.0.1:
         sauce-connect-version: "4.4.12"
 ```
 

--- a/hooks/command
+++ b/hooks/command
@@ -81,16 +81,24 @@ main() {
 
 halt_sc() {
   echo "--- :saucelabs: [sauce-connect] Stopping"
-  local pidfile="${TMP_DIR}/pid"
-  if [[ -e "${pidfile}" ]]; then
-    local pid
-    pid=$(cat "${pidfile}")
-    kill -SIGINT "${pid}"
-    while is_pid_alive "${pid}"; do
-      sleep 1
-    done
-    echo
-  fi
+
+  pushd "${TMP_DIR}" >/dev/null
+  local find_pidfiles
+  find_pidfiles=$(find . -name 'pid.*' -maxdepth 1 -type f)
+
+  local pidfile
+  while read -r pidfile; do
+    if [[ -e "${pidfile}" ]]; then
+      local pid
+      pid=$(cat "${pidfile}")
+      kill -SIGINT "${pid}" || true
+      while is_pid_alive "${pid}"; do
+        sleep 1
+      done
+      echo
+    fi
+  done <<< "${find_pidfiles}"
+  popd >/dev/null
   cleanup
 }
 
@@ -117,8 +125,8 @@ sc1() {
   local sauce_access_key="$4"
 
   echo "--- :saucelabs: [sauce-connect] Starting (Attempt ${attempt})"
-  local readyfile="${TMP_DIR}/ready"
-  local pidfile="${TMP_DIR}/pid"
+  local readyfile="${TMP_DIR}/ready.${attempt}"
+  local pidfile="${TMP_DIR}/pid.${attempt}"
 
   pushd "${TMP_DIR}" >/dev/null
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -32,7 +32,7 @@ stub_sc() {
   local args=( )
   local attempt
   for (( attempt=1; attempt<="${attempts}"; attempt++ )); do
-    args+=( "-u ${sauce_username} -k ${sauce_access_key} --tunnel-identifier ${tunnel_identifier} --readyfile ${TMP_DIR}/ready --pidfile ${TMP_DIR}/pid --logfile ${TMP_DIR}/sauce-connect.${attempt}.log --verbose : ${exec} ${attempt}" )
+    args+=( "-u ${sauce_username} -k ${sauce_access_key} --tunnel-identifier ${tunnel_identifier} --readyfile ${TMP_DIR}/ready.${attempt} --pidfile ${TMP_DIR}/pid.${attempt} --logfile ${TMP_DIR}/sauce-connect.${attempt}.log --verbose : ${exec} ${attempt}" )
   done
 
   stub sc "${args[@]}"
@@ -83,7 +83,7 @@ stub_sc() {
   export BUILDKITE_PLUGIN_SAUCE_CONNECT_TUNNEL_IDENTIFIER="my-config-identifier"
   export BUILDKITE_JOB_ID="my-job-id"
   
-  touch "${TMP_DIR}/ready"
+  touch "${TMP_DIR}/ready.1"
 
   stub_sc \
     "${TMP_DIR}" \
@@ -108,7 +108,7 @@ stub_sc() {
   export SAUCE_ACCESS_KEY="my-access-key"
   export BUILDKITE_JOB_ID="my-job-id"
 
-  touch "${TMP_DIR}/ready"
+  touch "${TMP_DIR}/ready.1"
 
   stub_sc \
     "${TMP_DIR}" \
@@ -151,7 +151,7 @@ stub_sc() {
   export BUILDKITE_JOB_ID="my-job-id"
   export BUILDKITE_COMMAND="my-command foo"
 
-  touch "${TMP_DIR}/ready"
+  touch "${TMP_DIR}/ready.1"
 
   stub_sc \
     "${TMP_DIR}" \


### PR DESCRIPTION
<img width="1046" alt="web__build_website_viewer__3697" src="https://user-images.githubusercontent.com/188038/39814128-735381a8-53d6-11e8-89b6-0f2e459b78a2.png">

On retries it is possible that the old pid file is still busy, this uses a different pid for each attempt.