### PR TITLE
Update plugin.yml and linter

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,8 +5,8 @@ steps:
         run: tests
   - label: ":sparkles: lint"
     plugins:
-      plugin-linter#v1.0.0:
-        name: sauce-connect
+      plugin-linter#v2.0.0:
+        id: joscha/sauce-connect
   - label: ":shell: Shellcheck"
     plugins:
       shellcheck#v1.0.1:

--- a/.ci/lint-plugin.sh
+++ b/.ci/lint-plugin.sh
@@ -9,6 +9,6 @@ docker run \
   --rm \
   -v "$(pwd):/plugin" \
   buildkite/plugin-linter \
-    --name joscha/sauce-connect
+    --id joscha/sauce-connect
 
 popd >/dev/null

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,4 +1,4 @@
-name: sauce-connect
+name: Sauce Connect
 description: Runs sauce-connect for a given step
 author: https://github.com/joscha
 requirements:


### PR DESCRIPTION
We've made some changes to plugin.yml which means we're recommending plain English plugin names (for a future plugin directory), and I've renamed the `--name` param of the linter to `--id` to avoid confusion (buildkite-plugins/buildkite-plugin-linter#15).

This updates the sauce connect plugin with the new conventions.