### PR TITLE
Update example YAML to use arrays for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ And like this on a connection failure:
 steps:
   - command: 'yarn && yarn saucelabs-based-tests'
     plugins:
-      joscha/sauce-connect#v2.1.0: ~
+      - joscha/sauce-connect#v2.1.0: ~
 ```
 
 ## Configuration
@@ -32,8 +32,8 @@ The tunnel identifier to use, by default it will use the Buildkite Job ID (`BUIL
 steps:
   - command: 'yarn && yarn saucelabs-based-tests'
     plugins:
-      joscha/sauce-connect#v2.1.0:
-        tunnel-identifier: "my-custom-tunnel-id"
+      - joscha/sauce-connect#v2.1.0:
+          tunnel-identifier: "my-custom-tunnel-id"
 ```
 
 ### `sauce-connect-version` (optional)
@@ -44,8 +44,8 @@ The Sauce Connect version to use, available versions, see [here](https://wiki.sa
 steps:
   - command: 'yarn && yarn saucelabs-based-tests'
     plugins:
-      joscha/sauce-connect#v2.1.0:
-        sauce-connect-version: "4.4.12"
+      - joscha/sauce-connect#v2.1.0:
+          sauce-connect-version: "4.4.12"
 ```
 
 ## Tests


### PR DESCRIPTION
Hi @joscha! 😊

Harriet from Buildkite here 👋🏻 We’ve [updated](https://buildkite.com/changelog/45-updated-syntax-for-using-plugins-in-your-pipeline-yaml) our recommended plugin syntax to use arrays instead of a map, to help ensure plugins are executed in the correct order with all agent versions.

This PR updates your readme example to be the new recommended syntax, and makes them pass the latest [plugin-linter](https://github.com/buildkite-plugins/buildkite-plugin-linter) checks.

Let me know if you have any questions! We’d love to get the readme updated so people use the new best-practice syntax.