### PR TITLE
fix: split command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) that opens a [sauce-connect tunnel](https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy).
 
-It contains a [command hook](hooks/command), and [tests](tests/command.bats) using [plugin-tester](https://github.com/buildkite-plugins/plugin-tester).
+It contains a [pre-command hook](hooks/pre-command), [pre-exit hook](hooks/pre-exit), and [tests](tests/command.bats) using [plugin-tester](https://github.com/buildkite-plugins/plugin-tester).
 
 ## Example
 

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -4,16 +4,13 @@ set -euo pipefail
 # Allow to pass TMP_DIR for testing purposes
 if [[ -z "${TMP_DIR:-}" ]]; then
   TMP_DIR=$(mktemp -d -t sauce-connect-buildkite-plugin.XXXXXXXXXX)
+  export BUILDKITE_PLUGIN_SAUCE_CONNECT_TMP_DIR="${TMP_DIR}"
   function cleanup {
     echo "Cleaning up ${TMP_DIR}"
     rm -rf "${TMP_DIR}"
   }
-else
-  function cleanup {
-    echo "Not removing given TMP_DIR (${TMP_DIR})"
-  }
+  trap cleanup ERR
 fi
-trap halt_sc EXIT
 
 # See https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy
 DEFAULT_SAUCE_CONNECT_VERSION="4.5.3"
@@ -75,46 +72,6 @@ main() {
     "${tunnel_identifier}" \
     "${SAUCE_USERNAME}" \
     "${SAUCE_ACCESS_KEY}"
-
-  run_buildkite_command
-}
-
-halt_sc() {
-  echo "--- :saucelabs: [sauce-connect] Stopping"
-
-  pushd "${TMP_DIR}" >/dev/null
-  local find_pidfiles
-  find_pidfiles=$(find . -maxdepth 1 -name 'pid.*' -type f)
-
-  local pidfile
-  while read -r pidfile; do
-    if [[ -e "${pidfile}" ]]; then
-      local pid
-      pid=$(cat "${pidfile}")
-      kill -SIGINT "${pid}" || true
-      local counter=0
-      while is_pid_alive "${pid}"; do
-        sleep 1
-        counter=$((counter+1))
-        if [[ "${counter}" -gt 60 ]]; then
-          # try to kill again after a minute
-          kill -SIGINT "${pid}" 2>/dev/null || true
-        fi
-      done
-      echo
-    fi
-  done <<< "${find_pidfiles}"
-  popd >/dev/null
-  cleanup
-}
-
-run_buildkite_command() {
-  if [[ -n "${BUILDKITE_COMMAND:-}" ]]; then
-    echo "--- :saucelabs: [sauce-connect] Running command"
-    echo "Command: ${BUILDKITE_COMMAND}"
-    echo
-    bash -c "${BUILDKITE_COMMAND}"
-  fi
 }
 
 sc3() {

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -euo pipefail
+
+# Allow to pass TMP_DIR for testing purposes
+if [[ -z "${TMP_DIR:-}" ]]; then
+  TMP_DIR="${BUILDKITE_PLUGIN_SAUCE_CONNECT_TMP_DIR}"
+  function cleanup {
+    echo "Cleaning up ${TMP_DIR}"
+    if [[ -d "${TMP_DIR}" ]]; then
+        rm -rf "${TMP_DIR}"
+    fi
+  }
+else
+  function cleanup {
+    echo "Not removing given TMP_DIR (${TMP_DIR})"
+  }
+fi
+trap cleanup EXIT
+
+is_pid_alive() {
+  local pid="$1"
+  kill -0 "${pid}" >/dev/null 2>&1
+}
+
+halt_sc() {
+  echo "--- :saucelabs: [sauce-connect] Stopping"
+
+  pushd "${TMP_DIR}" >/dev/null
+  local find_pidfiles
+  find_pidfiles=$(find . -maxdepth 1 -name 'pid.*' -type f)
+
+  local pidfile
+  while read -r pidfile; do
+    if [[ -e "${pidfile}" ]]; then
+      local pid
+      pid=$(cat "${pidfile}")
+      kill -SIGINT "${pid}" || true
+      local counter=0
+      while is_pid_alive "${pid}"; do
+        sleep 1
+        counter=$((counter+1))
+        if [[ "${counter}" -gt 60 ]]; then
+          # try to kill again after a minute
+          kill -SIGINT "${pid}" 2>/dev/null || true
+        fi
+      done
+      echo
+    fi
+  done <<< "${find_pidfiles}"
+  popd >/dev/null
+}
+
+halt_sc

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -42,7 +42,7 @@ stub_sc() {
   export SAUCE_USERNAME=""
   export SAUCE_ACCESS_KEY=""
 
-  run "${PWD}/hooks/command"
+  run "${PWD}/hooks/pre-command"
 
   assert_failure
   assert_output --partial "SAUCE_USERNAME not set"
@@ -55,7 +55,7 @@ stub_sc() {
   export SAUCE_USERNAME="my-username"
   export SAUCE_ACCESS_KEY=""
   
-  run "${PWD}/hooks/command"
+  run "${PWD}/hooks/pre-command"
 
   assert_failure
   assert_output --partial "SAUCE_ACCESS_KEY not set"
@@ -68,7 +68,7 @@ stub_sc() {
   export SAUCE_USERNAME="my-username"
   export SAUCE_ACCESS_KEY="my-access-key"
 
-  run "${PWD}/hooks/command"
+  run "${PWD}/hooks/pre-command"
 
   assert_failure
   assert_output --partial "BUILDKITE_JOB_ID not set"
@@ -91,7 +91,7 @@ stub_sc() {
     "${SAUCE_ACCESS_KEY}" \
     "${BUILDKITE_PLUGIN_SAUCE_CONNECT_TUNNEL_IDENTIFIER}"
 
-  run "${PWD}/hooks/command"
+  run "${PWD}/hooks/pre-command"
 
   assert_success
 
@@ -116,7 +116,7 @@ stub_sc() {
     "${SAUCE_ACCESS_KEY}" \
     "${BUILDKITE_JOB_ID}"
 
-  run "${PWD}/hooks/command"
+  run "${PWD}/hooks/pre-command"
 
   assert_success
 
@@ -134,7 +134,7 @@ stub_sc() {
   local ORIGINAL_OSTYPE="${OSTYPE}"
   export OSTYPE="fancy-arch"
 
-  run "${PWD}/hooks/command"
+  run "${PWD}/hooks/pre-command"
 
   assert_failure
   assert_output --partial "unknown OS: ${OSTYPE}"
@@ -143,37 +143,6 @@ stub_sc() {
   unset SAUCE_ACCESS_KEY
   unset BUILDKITE_JOB_ID
   export OSTYPE="${ORIGINAL_OSTYPE}"
-}
-
-@test "Command runs BUILDKITE_COMMAND after the tunnel has been started" {
-  export SAUCE_USERNAME="my-username"
-  export SAUCE_ACCESS_KEY="my-access-key"
-  export BUILDKITE_JOB_ID="my-job-id"
-  export BUILDKITE_COMMAND="my-command foo"
-
-  touch "${TMP_DIR}/ready.1"
-
-  stub_sc \
-    "${TMP_DIR}" \
-    "${SAUCE_USERNAME}" \
-    "${SAUCE_ACCESS_KEY}" \
-    "${BUILDKITE_JOB_ID}"
-
-  stub my-command "foo : echo 'All systems green'"
-
-  run "${PWD}/hooks/command"
-
-  assert_success
-  assert_output --partial "sauce-connect is up \o/"
-  assert_output --partial "All systems green"
-
-  unstub sc
-  unstub my-command
-
-  unset SAUCE_USERNAME
-  unset SAUCE_ACCESS_KEY
-  unset BUILDKITE_JOB_ID
-  unset BUILDKITE_COMMAND
 }
 
 attempts=3
@@ -193,7 +162,7 @@ attempts=3
 
   stub sleep
 
-  run "${PWD}/hooks/command"
+  run "${PWD}/hooks/pre-command"
 
   assert_failure
   assert_output --partial "Failed to connect!"


### PR DESCRIPTION
enables chaining plugins, details, see: https://buildkite-community.slack.com/archives/C02T53V9H/p1572934188225300


> I am trying to combine two plugins:
• https://github.com/joscha/sauce-connect-buildkite-plugin
• https://github.com/buildkite-plugins/docker-buildkite-plugin
The idea is that the sauce-connect plugin opens a VPN tunnel to saucelabs and the command that uses this resource is running inside a docker image.
Now the problem that I am encountering is that the sauce-connect plugin uses the command hook, same as the docker plugin, which effectively means that the command does not not get executed inside the docker plugin, but one step too early
sauce-connect hook: https://github.com/joscha/sauce-connect-buildkite-plugin/blob/89d1dad1579c2af30c8c388524c09041659d76cf/hooks/command
docker hook: https://github.com/buildkite-plugins/docker-buildkite-plugin/blob/master/hooks/command
I can see that this is deliberate https://github.com/buildkite/agent/blob/3917b6c26685b99d484ad3a01acbdb358efdb387/bootstrap/bootstrap.go#L671 so I am wondering what changes I need to make in order to make this work. I am currently thinking of changing the sauce-connect plugin to use the pre-command hook, but it is relying on a trap (https://github.com/joscha/sauce-connect-buildkite-plugin/blob/89d1dad1579c2af30c8c388524c09041659d76cf/hooks/command#L16) in order to close the tunnel after the execution. I want to also close the tunnel when the next plugin invocation failed, but because this is managed by the docker plugin I am not sure how to do that. Is the right way of doing this to use a post-command hook (https://buildkite.com/docs/agent/v3/hooks) inside the first plugin?