### PR TITLE
fix: retry and exit gracefully

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -40,13 +40,15 @@ maybe_download_sc() {
   case "${OSTYPE}" in
     linux*)
       os="linux"
-      curl -fsSL "https://saucelabs.com/downloads/sc-${sauce_connect_version}-${os}.tar.gz" | tar -xzf - "sc-${sauce_connect_version}-${os}/bin/sc"
+      # TODO: cache this download on the agent
+      curl -fsSL --retry 5 "https://saucelabs.com/downloads/sc-${sauce_connect_version}-${os}.tar.gz" | tar -xzf - "sc-${sauce_connect_version}-${os}/bin/sc"
       mv "./sc-${sauce_connect_version}-${os}/bin/sc" ./sc
       rm -rf "./sc-${sauce_connect_version}-${os}/bin"
     ;;
     darwin*)
       os="osx"
-      curl -fsSL -o sc.zip "https://saucelabs.com/downloads/sc-${sauce_connect_version}-${os}.zip"
+      # TODO: cache this download on the agent
+      curl -fsSL --retry 5 -o sc.zip "https://saucelabs.com/downloads/sc-${sauce_connect_version}-${os}.zip"
       unzip -p sc.zip "sc-${sauce_connect_version}-${os}/bin/sc" > ./sc
       rm sc.zip
       chmod +x ./sc

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -3,7 +3,8 @@ set -euo pipefail
 
 # Allow to pass TMP_DIR for testing purposes
 if [[ -z "${TMP_DIR:-}" ]]; then
-  TMP_DIR="${BUILDKITE_PLUGIN_SAUCE_CONNECT_TMP_DIR}"
+  # BUILDKITE_PLUGIN_SAUCE_CONNECT_TMP_DIR can be empty if the pre-command failed
+  TMP_DIR="${BUILDKITE_PLUGIN_SAUCE_CONNECT_TMP_DIR:-}"
   function cleanup {
     echo "Cleaning up ${TMP_DIR}"
     if [[ -d "${TMP_DIR}" ]]; then


### PR DESCRIPTION
curl can fail, e.g.:
```
curl: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to saucelabs.com:443
```

in that case the temp dir is not exported properly and thus the cleanup will fail with:
```
/etc/buildkite-agent/plugins/github-com-joscha-sauce-connect-buildkite-plugin-v3-0-0/hooks/pre-exit: line 6: BUILDKITE_PLUGIN_SAUCE_CONNECT_TMP_DIR: unbound variable
```

This PR fixes the flow-on (e.g. `BUILDKITE_PLUGIN_SAUCE_CONNECT_TMP_DIR` not exported correctly) and also attempts to retry the sc binary.
