### PR TITLE
ensure TMP_DIR exists

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -6,6 +6,7 @@ PLUGIN_NAME=sauce-connect-buildkite-plugin
 # Allow to pass TMP_DIR for testing purposes
 if [[ -z "${TMP_DIR:-}" ]]; then
   TMP_DIR="${TMPDIR:-/tmp}/${PLUGIN_NAME}"
+  mkdir -p "${TMP_DIR}"
   export BUILDKITE_PLUGIN_SAUCE_CONNECT_TMP_DIR="${TMP_DIR}"
 fi
 


### PR DESCRIPTION
When not overwriting `TMP_DIR`, running this fails with `pushd: /tmp/sauce-connect-buildkite-plugin: No such file or directory`. Ensuring the dir exists with `mkdir -p $TMP_DIR` will fix this (don't strictly need `-p` but why not?)